### PR TITLE
BUS-11133 feat: Substituir o uso da API externa por salvamento de evento na tabela de outbox

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,10 @@ dependencies {
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
     testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 }
+
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/pagsestagio/movieapi/controller/FilmeControllerV2.java
+++ b/src/main/java/com/pagsestagio/movieapi/controller/FilmeControllerV2.java
@@ -1,10 +1,10 @@
 package com.pagsestagio.movieapi.controller;
 
+import com.pagsestagio.movieapi.controller.resposta.FilmeResposta;
 import com.pagsestagio.movieapi.controller.resposta.FilmeRespostaRetornaFilmeOuMensagem;
 import com.pagsestagio.movieapi.model.FilmeDTOV2;
-import com.pagsestagio.movieapi.service.FilmeService;
-import com.pagsestagio.movieapi.controller.resposta.FilmeResposta;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuMensagem;
+import com.pagsestagio.movieapi.service.FilmeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/pagsestagio/movieapi/model/FilmeOutboxDTO.java
+++ b/src/main/java/com/pagsestagio/movieapi/model/FilmeOutboxDTO.java
@@ -1,0 +1,5 @@
+package com.pagsestagio.movieapi.model;
+
+public record FilmeOutboxDTO(String nomeFilme) {
+
+}

--- a/src/main/java/com/pagsestagio/movieapi/model/FilmeOutboxDTO.java
+++ b/src/main/java/com/pagsestagio/movieapi/model/FilmeOutboxDTO.java
@@ -1,5 +1,0 @@
-package com.pagsestagio.movieapi.model;
-
-public record FilmeOutboxDTO(String nomeFilme) {
-
-}

--- a/src/main/java/com/pagsestagio/movieapi/model/FilmeOutboxPayload.java
+++ b/src/main/java/com/pagsestagio/movieapi/model/FilmeOutboxPayload.java
@@ -1,0 +1,5 @@
+package com.pagsestagio.movieapi.model;
+
+public record FilmeOutboxPayload(String nomeFilme) {
+
+}

--- a/src/main/java/com/pagsestagio/movieapi/repository/FilmeOutboxRepository.java
+++ b/src/main/java/com/pagsestagio/movieapi/repository/FilmeOutboxRepository.java
@@ -4,6 +4,7 @@ import com.pagsestagio.movieapi.model.FilmeOutbox;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+//Alteração feita aqui(Novo repositório criado para a entidade FilmeOutbox)
 @Repository
 public interface FilmeOutboxRepository extends JpaRepository<FilmeOutbox, Long> {
 

--- a/src/main/java/com/pagsestagio/movieapi/repository/FilmeOutboxRepository.java
+++ b/src/main/java/com/pagsestagio/movieapi/repository/FilmeOutboxRepository.java
@@ -1,0 +1,10 @@
+package com.pagsestagio.movieapi.repository;
+
+import com.pagsestagio.movieapi.model.FilmeOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FilmeOutboxRepository extends JpaRepository<FilmeOutbox, Long> {
+
+}

--- a/src/main/java/com/pagsestagio/movieapi/repository/FilmeOutboxRepository.java
+++ b/src/main/java/com/pagsestagio/movieapi/repository/FilmeOutboxRepository.java
@@ -4,7 +4,6 @@ import com.pagsestagio.movieapi.model.FilmeOutbox;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-//Alteração feita aqui(Novo repositório criado para a entidade FilmeOutbox)
 @Repository
 public interface FilmeOutboxRepository extends JpaRepository<FilmeOutbox, Long> {
 

--- a/src/main/java/com/pagsestagio/movieapi/service/FilmeOutboxService.java
+++ b/src/main/java/com/pagsestagio/movieapi/service/FilmeOutboxService.java
@@ -1,0 +1,46 @@
+package com.pagsestagio.movieapi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pagsestagio.movieapi.model.Filme;
+import com.pagsestagio.movieapi.model.FilmeOutbox;
+import com.pagsestagio.movieapi.model.FilmeOutboxDTO;
+import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class FilmeOutboxService {
+
+    private static final String TOPIC_DESTINO = "movie-api.informacoes-adicionais-filme";
+
+    private final FilmeOutboxRepository filmeOutboxRepository;
+    private final ObjectMapper objectMapper;
+
+
+    public FilmeOutboxService(FilmeOutboxRepository filmeOutboxRepository, ObjectMapper objectMapper) {
+        this.filmeOutboxRepository = filmeOutboxRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void salvaEventoNaTabelaDeOutbox(Filme filme) {
+        try {
+            FilmeOutbox filmeOutbox = new FilmeOutbox();
+            filmeOutbox.setKey(filme.getIdPublico().toString());
+
+            FilmeOutboxDTO objeto = new FilmeOutboxDTO(filme.getNomeFilme());
+            String payload = objectMapper.writeValueAsString(objeto);
+            filmeOutbox.setPayload(payload);
+
+            filmeOutbox.setCriadoEm(LocalDateTime.now());
+            filmeOutbox.setTopicoDestino(TOPIC_DESTINO);
+            filmeOutbox.setProcessado(false);
+
+            filmeOutboxRepository.save(filmeOutbox);
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao salvar evento na tabela de outbox", e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/pagsestagio/movieapi/service/FilmeOutboxService.java
+++ b/src/main/java/com/pagsestagio/movieapi/service/FilmeOutboxService.java
@@ -3,7 +3,7 @@ package com.pagsestagio.movieapi.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeOutbox;
-import com.pagsestagio.movieapi.model.FilmeOutboxDTO;
+import com.pagsestagio.movieapi.model.FilmeOutboxPayload;
 import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import org.springframework.stereotype.Service;
 
@@ -28,7 +28,7 @@ public class FilmeOutboxService {
             FilmeOutbox filmeOutbox = new FilmeOutbox();
             filmeOutbox.setKey(filme.getIdPublico().toString());
 
-            FilmeOutboxDTO objeto = new FilmeOutboxDTO(filme.getNomeFilme());
+            FilmeOutboxPayload objeto = new FilmeOutboxPayload(filme.getNomeFilme());
             String payload = objectMapper.writeValueAsString(objeto);
             filmeOutbox.setPayload(payload);
 

--- a/src/main/java/com/pagsestagio/movieapi/service/FilmeService.java
+++ b/src/main/java/com/pagsestagio/movieapi/service/FilmeService.java
@@ -24,8 +24,11 @@ import java.util.UUID;
 public class FilmeService {
 
     private final FilmeRepository filmeRepository;
+
+    //Alteração feita aqui
     private final FilmeOutboxRepository filmeOutboxRepository;
 
+    //Alteração feita aqui
     @Autowired
     public FilmeService(FilmeRepository filmeRepository, OmdbService omdbService, FilmeOutboxRepository filmeOutboxRepository) {
         this.filmeRepository = filmeRepository;
@@ -122,6 +125,7 @@ public class FilmeService {
         return retornoCriacaoDeFilme;
     }
 
+    //Alteração feita aqui
     @Transactional
     public FilmeResultadoRetornaFilmeOuMensagem criarFilmeV2(FilmeDTOV2 filmeRequisicao) {
         FilmeResultadoRetornaFilmeOuMensagem retornoCriacaoDeFilme = null;

--- a/src/main/java/com/pagsestagio/movieapi/service/FilmeService.java
+++ b/src/main/java/com/pagsestagio/movieapi/service/FilmeService.java
@@ -1,20 +1,16 @@
 package com.pagsestagio.movieapi.service;
 
-import com.pagsestagio.movieapi.apiExterna.omdb.service.OmdbService;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeDTOV1;
 import com.pagsestagio.movieapi.model.FilmeDTOV2;
-import com.pagsestagio.movieapi.model.FilmeOutbox;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuExcecaoV1;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuMensagem;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaListaDeFilmesOuExcecaoV1;
-import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import com.pagsestagio.movieapi.repository.FilmeRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -24,19 +20,14 @@ import java.util.UUID;
 public class FilmeService {
 
     private final FilmeRepository filmeRepository;
+    private final FilmeOutboxService filmeOutboxService;
 
-    //Alteração feita aqui
-    private final FilmeOutboxRepository filmeOutboxRepository;
 
-    //Alteração feita aqui
     @Autowired
-    public FilmeService(FilmeRepository filmeRepository, OmdbService omdbService, FilmeOutboxRepository filmeOutboxRepository) {
+    public FilmeService(FilmeRepository filmeRepository, FilmeOutboxService filmeOutboxService) {
         this.filmeRepository = filmeRepository;
-        this.omdbService = omdbService;
-        this.filmeOutboxRepository = filmeOutboxRepository;
+        this.filmeOutboxService = filmeOutboxService;
     }
-
-    private OmdbService omdbService;
 
     List<FilmeDTOV1> getListaDeFilmesVersaoUm() {
         List<Filme> filmesComIdLegado = filmeRepository.findAllByIdLegadoIsNotNull();
@@ -157,14 +148,8 @@ public class FilmeService {
 
             filmeRepository.save(filmeCriado);
 
-            FilmeOutbox filmeOutbox = new FilmeOutbox();
-            filmeOutbox.setKey(filmeCriado.getIdPublico().toString());
-            filmeOutbox.setPayload(filmeCriado.getNomeFilme());
-            filmeOutbox.setCriadoEm(LocalDateTime.now());
-            filmeOutbox.setTopicoDestino("movie-api.informacoes-adicionais-filme");
-            filmeOutbox.setProcessado(false);
 
-            filmeOutboxRepository.save(filmeOutbox);
+            filmeOutboxService.salvaEventoNaTabelaDeOutbox(filmeCriado);
 
 
             retornoCriacaoDeFilme =

--- a/src/main/java/com/pagsestagio/movieapi/service/FilmeService.java
+++ b/src/main/java/com/pagsestagio/movieapi/service/FilmeService.java
@@ -1,295 +1,293 @@
 package com.pagsestagio.movieapi.service;
 
 import com.pagsestagio.movieapi.apiExterna.omdb.service.OmdbService;
-import com.pagsestagio.movieapi.apiExterna.resposta.FilmeRespostaApiExternaRetornaDadosFilme;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeDTOV1;
 import com.pagsestagio.movieapi.model.FilmeDTOV2;
+import com.pagsestagio.movieapi.model.FilmeOutbox;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuExcecaoV1;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuMensagem;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaListaDeFilmesOuExcecaoV1;
+import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import com.pagsestagio.movieapi.repository.FilmeRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 @Service
 public class FilmeService {
 
-  private final FilmeRepository filmeRepository;
+    private final FilmeRepository filmeRepository;
+    private final FilmeOutboxRepository filmeOutboxRepository;
 
-  @Autowired
-  public FilmeService(FilmeRepository filmeRepository, OmdbService omdbService) {
-    this.filmeRepository = filmeRepository;
-    this.omdbService = omdbService;
-  }
-
-  private OmdbService omdbService;
-
-  List<FilmeDTOV1> getListaDeFilmesVersaoUm() {
-    List<Filme> filmesComIdLegado = filmeRepository.findAllByIdLegadoIsNotNull();
-    List<FilmeDTOV1> listaDeFilmes = new ArrayList<>();
-
-    for (Filme filme : filmesComIdLegado) {
-      FilmeDTOV1 filmeLegadoDTOV1 = new FilmeDTOV1(filme.getIdLegado(), filme.getNomeFilme());
-      listaDeFilmes.add(filmeLegadoDTOV1);
+    @Autowired
+    public FilmeService(FilmeRepository filmeRepository, OmdbService omdbService, FilmeOutboxRepository filmeOutboxRepository) {
+        this.filmeRepository = filmeRepository;
+        this.omdbService = omdbService;
+        this.filmeOutboxRepository = filmeOutboxRepository;
     }
 
-    return listaDeFilmes;
-  }
+    private OmdbService omdbService;
 
-  @Deprecated
-  public FilmeResultadoRetornaFilmeOuExcecaoV1 pegarFilmePeloIdV1(Integer idRequisicao) {
-    FilmeResultadoRetornaFilmeOuExcecaoV1 retornoDoFilmePorIdentificador = null;
+    List<FilmeDTOV1> getListaDeFilmesVersaoUm() {
+        List<Filme> filmesComIdLegado = filmeRepository.findAllByIdLegadoIsNotNull();
+        List<FilmeDTOV1> listaDeFilmes = new ArrayList<>();
 
-    Optional<Filme> optionalFilme = filmeRepository.findByIdLegado(idRequisicao);
+        for (Filme filme : filmesComIdLegado) {
+            FilmeDTOV1 filmeLegadoDTOV1 = new FilmeDTOV1(filme.getIdLegado(), filme.getNomeFilme());
+            listaDeFilmes.add(filmeLegadoDTOV1);
+        }
 
-    if (optionalFilme.isPresent()) {
-      String nomeDoFilmeEncontrado = optionalFilme.get().getNomeFilme();
-      retornoDoFilmePorIdentificador =
-          new FilmeResultadoRetornaFilmeOuExcecaoV1(
-              optionalFilme.get().getId(), nomeDoFilmeEncontrado, null);
-    } else {
-      retornoDoFilmePorIdentificador =
-          new FilmeResultadoRetornaFilmeOuExcecaoV1(
-              null, null, "Identificador não encontrado! Não foi possível obter o filme.");
+        return listaDeFilmes;
     }
 
-    return retornoDoFilmePorIdentificador;
-  }
+    @Deprecated
+    public FilmeResultadoRetornaFilmeOuExcecaoV1 pegarFilmePeloIdV1(Integer idRequisicao) {
+        FilmeResultadoRetornaFilmeOuExcecaoV1 retornoDoFilmePorIdentificador = null;
 
-  public FilmeResultadoRetornaFilmeOuMensagem pegarFilmePeloIdV2(UUID idRequisicao) {
-    FilmeResultadoRetornaFilmeOuMensagem retornoDoFilmePorIdentificador = null;
-    Optional<Filme> optionalFilme = filmeRepository.findByIdPublico(idRequisicao);
+        Optional<Filme> optionalFilme = filmeRepository.findByIdLegado(idRequisicao);
 
-    if (optionalFilme.isPresent()) {
-      Filme filmeprocurado = optionalFilme.get();
-      retornoDoFilmePorIdentificador =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              filmeprocurado.getIdPublico(),
-              filmeprocurado.getNomeFilme(),
-              filmeprocurado.getSinopseFilme(),
-              filmeprocurado.getCategoriaFilme(),
-              filmeprocurado.getAnoFilme(),
-              filmeprocurado.getDiretorFilme());
-    } else {
-      retornoDoFilmePorIdentificador =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              "Identificador não encontrado! Não foi possível obter o filme.");
+        if (optionalFilme.isPresent()) {
+            String nomeDoFilmeEncontrado = optionalFilme.get().getNomeFilme();
+            retornoDoFilmePorIdentificador =
+                    new FilmeResultadoRetornaFilmeOuExcecaoV1(
+                            optionalFilme.get().getId(), nomeDoFilmeEncontrado, null);
+        } else {
+            retornoDoFilmePorIdentificador =
+                    new FilmeResultadoRetornaFilmeOuExcecaoV1(
+                            null, null, "Identificador não encontrado! Não foi possível obter o filme.");
+        }
+
+        return retornoDoFilmePorIdentificador;
     }
 
-    return retornoDoFilmePorIdentificador;
-  }
+    public FilmeResultadoRetornaFilmeOuMensagem pegarFilmePeloIdV2(UUID idRequisicao) {
+        FilmeResultadoRetornaFilmeOuMensagem retornoDoFilmePorIdentificador = null;
+        Optional<Filme> optionalFilme = filmeRepository.findByIdPublico(idRequisicao);
 
-  @Deprecated
-  @Transactional
-  public FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 criarFilmeV1(FilmeDTOV1 filmeRequisicao) {
-    FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 retornoCriacaoDeFilme = null;
+        if (optionalFilme.isPresent()) {
+            Filme filmeprocurado = optionalFilme.get();
+            retornoDoFilmePorIdentificador =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            filmeprocurado.getIdPublico(),
+                            filmeprocurado.getNomeFilme(),
+                            filmeprocurado.getSinopseFilme(),
+                            filmeprocurado.getCategoriaFilme(),
+                            filmeprocurado.getAnoFilme(),
+                            filmeprocurado.getDiretorFilme());
+        } else {
+            retornoDoFilmePorIdentificador =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            "Identificador não encontrado! Não foi possível obter o filme.");
+        }
 
-    Optional<Filme> filmeExistente =
-        filmeRepository.findByNomeFilme(filmeRequisicao.getNomeFilme());
-
-    if (filmeRequisicao.getIdLegado() == null || filmeRequisicao.getNomeFilme() == null) {
-      retornoCriacaoDeFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
-              null, "O identificador e o nome do filme devem ser inseridos.");
-    } else if (filmeExistente.isPresent()
-        || filmeRepository.existsByIdLegado(filmeRequisicao.getIdLegado())) {
-      retornoCriacaoDeFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
-              null, "O registro já existe, faça um PUT para atualizar.");
-    } else {
-      Filme filmecriado = new Filme();
-      filmecriado.setIdLegado(filmeRequisicao.getIdLegado());
-      filmecriado.setNomeFilme(filmeRequisicao.getNomeFilme());
-      filmeRepository.save(filmecriado);
-
-      List<FilmeDTOV1> listaDeFilmes = getListaDeFilmesVersaoUm();
-
-      retornoCriacaoDeFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(listaDeFilmes, null);
+        return retornoDoFilmePorIdentificador;
     }
 
-    return retornoCriacaoDeFilme;
-  }
+    @Deprecated
+    @Transactional
+    public FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 criarFilmeV1(FilmeDTOV1 filmeRequisicao) {
+        FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 retornoCriacaoDeFilme = null;
 
-  @Transactional
-  public FilmeResultadoRetornaFilmeOuMensagem criarFilmeV2(FilmeDTOV2 filmeRequisicao) {
-    FilmeResultadoRetornaFilmeOuMensagem retornoCriacaoDeFilme = null;
+        Optional<Filme> filmeExistente =
+                filmeRepository.findByNomeFilme(filmeRequisicao.getNomeFilme());
 
-    Optional<Filme> filmeExistente =
-        filmeRepository.findByNomeFilme(filmeRequisicao.getNomeFilme());
+        if (filmeRequisicao.getIdLegado() == null || filmeRequisicao.getNomeFilme() == null) {
+            retornoCriacaoDeFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
+                            null, "O identificador e o nome do filme devem ser inseridos.");
+        } else if (filmeExistente.isPresent()
+                || filmeRepository.existsByIdLegado(filmeRequisicao.getIdLegado())) {
+            retornoCriacaoDeFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
+                            null, "O registro já existe, faça um PUT para atualizar.");
+        } else {
+            Filme filmecriado = new Filme();
+            filmecriado.setIdLegado(filmeRequisicao.getIdLegado());
+            filmecriado.setNomeFilme(filmeRequisicao.getNomeFilme());
+            filmeRepository.save(filmecriado);
 
-    if (filmeRequisicao.getNomeFilme() == null) {
-      retornoCriacaoDeFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem("O nome do filme é obrigatório.");
-    } else if (filmeExistente.isPresent()) {
-      retornoCriacaoDeFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              "Este filme já está cadastrado com o seguinte ID: "
-                  + filmeExistente.get().getIdPublico()
-                  + ". Faça um PUT para atualizar.");
-    } else {
+            List<FilmeDTOV1> listaDeFilmes = getListaDeFilmesVersaoUm();
 
-      FilmeRespostaApiExternaRetornaDadosFilme filmeDaApiExterna =
-          omdbService.getFilmePorNome(filmeRequisicao.getNomeFilme());
+            retornoCriacaoDeFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(listaDeFilmes, null);
+        }
 
-      Filme filmeCriado = null;
-
-      if (filmeDaApiExterna != null && filmeDaApiExterna.nomeFilme() != null) {
-        filmeCriado =
-            new Filme(
-                null,
-                null,
-                null,
-                filmeDaApiExterna.nomeFilme(),
-                filmeDaApiExterna.sinopseFilme(),
-                filmeDaApiExterna.categoriaFilme(),
-                filmeDaApiExterna.anoFilme(),
-                filmeDaApiExterna.diretorFilme());
-      } else {
-        filmeCriado =
-            new Filme(
-                null,
-                null,
-                null,
-                filmeRequisicao.getNomeFilme(),
-                filmeRequisicao.getSinopseFilme(),
-                filmeRequisicao.getCategoriaFilme(),
-                filmeRequisicao.getAnoFilme(),
-                filmeRequisicao.getDiretorFilme());
-      }
-
-      filmeRepository.save(filmeCriado);
-
-      retornoCriacaoDeFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              filmeCriado.getIdPublico(),
-              filmeCriado.getNomeFilme(),
-              filmeCriado.getSinopseFilme(),
-              filmeCriado.getCategoriaFilme(),
-              filmeCriado.getAnoFilme(),
-              filmeCriado.getDiretorFilme());
+        return retornoCriacaoDeFilme;
     }
 
-    return retornoCriacaoDeFilme;
-  }
+    @Transactional
+    public FilmeResultadoRetornaFilmeOuMensagem criarFilmeV2(FilmeDTOV2 filmeRequisicao) {
+        FilmeResultadoRetornaFilmeOuMensagem retornoCriacaoDeFilme = null;
 
-  @Deprecated
-  @Transactional
-  public FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 atualizarFilmeV1(
-      FilmeDTOV1 filmeRequisicao) {
+        Optional<Filme> filmeExistente =
+                filmeRepository.findByNomeFilme(filmeRequisicao.getNomeFilme());
 
-    FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 retornoAtualizacaoFilme = null;
+        if (filmeRequisicao.getNomeFilme() == null) {
+            retornoCriacaoDeFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem("O nome do filme é obrigatório.");
+        } else if (filmeExistente.isPresent()) {
+            retornoCriacaoDeFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            "Este filme já está cadastrado com o seguinte ID: "
+                                    + filmeExistente.get().getIdPublico()
+                                    + ". Faça um PUT para atualizar.");
+        } else {
 
-    Optional<Filme> filmeExistente = filmeRepository.findByIdLegado(filmeRequisicao.getIdLegado());
+            Filme filmeCriado = new Filme(
+                    null,
+                    null,
+                    null,
+                    filmeRequisicao.getNomeFilme(),
+                    filmeRequisicao.getSinopseFilme(),
+                    filmeRequisicao.getCategoriaFilme(),
+                    filmeRequisicao.getAnoFilme(),
+                    filmeRequisicao.getDiretorFilme());
 
-    if (filmeRequisicao.getNomeFilme() != null
-        && filmeRequisicao.getIdLegado() != null
-        && filmeExistente.isPresent()) {
-      Filme filmeAtualizado = filmeExistente.get();
-      filmeAtualizado.setNomeFilme(filmeRequisicao.getNomeFilme());
-      filmeRepository.save(filmeAtualizado);
 
-      List<FilmeDTOV1> listaDeFilmes = getListaDeFilmesVersaoUm();
+            filmeRepository.save(filmeCriado);
 
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(listaDeFilmes, null);
-    } else if (filmeRequisicao.getNomeFilme() == null || filmeRequisicao.getIdLegado() == null) {
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
-              null, "O identificador e o nome do filme são obrigatórios.");
-    } else {
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
-              null, "O registro não existe, faça um POST para inserir.");
+            FilmeOutbox filmeOutbox = new FilmeOutbox();
+            filmeOutbox.setKey(filmeCriado.getIdPublico().toString());
+            filmeOutbox.setPayload(filmeCriado.getNomeFilme());
+            filmeOutbox.setCriadoEm(LocalDateTime.now());
+            filmeOutbox.setTopicoDestino("movie-api.informacoes-adicionais-filme");
+            filmeOutbox.setProcessado(false);
+
+            filmeOutboxRepository.save(filmeOutbox);
+
+
+            retornoCriacaoDeFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            filmeCriado.getIdPublico(),
+                            filmeCriado.getNomeFilme(),
+                            filmeCriado.getSinopseFilme(),
+                            filmeCriado.getCategoriaFilme(),
+                            filmeCriado.getAnoFilme(),
+                            filmeCriado.getDiretorFilme());
+
+        }
+
+        return retornoCriacaoDeFilme;
     }
 
-    return retornoAtualizacaoFilme;
-  }
+    @Deprecated
+    @Transactional
+    public FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 atualizarFilmeV1(
+            FilmeDTOV1 filmeRequisicao) {
 
-  @Transactional
-  public FilmeResultadoRetornaFilmeOuMensagem atualizarFilmeV2(FilmeDTOV2 filmeRequisicao) {
-    FilmeResultadoRetornaFilmeOuMensagem retornoAtualizacaoFilme = null;
-    Optional<Filme> filmeExistente =
-        filmeRepository.findByIdPublico(filmeRequisicao.getIdPublico());
+        FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 retornoAtualizacaoFilme = null;
 
-    if (filmeRequisicao.getIdPublico() == null) {
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem("É obrigatório informar o ID do filme.");
-    } else if (filmeExistente.isPresent() && filmeRequisicao.getNomeFilme() != null) {
-      Filme filmeatualizado = filmeExistente.get();
-      filmeatualizado.setNomeFilme(filmeRequisicao.getNomeFilme());
-      filmeatualizado.setSinopseFilme(filmeRequisicao.getSinopseFilme());
-      filmeatualizado.setCategoriaFilme(filmeRequisicao.getCategoriaFilme());
-      filmeatualizado.setAnoFilme(filmeRequisicao.getAnoFilme());
-      filmeatualizado.setDiretorFilme(filmeRequisicao.getDiretorFilme());
-      filmeRepository.save(filmeatualizado);
+        Optional<Filme> filmeExistente = filmeRepository.findByIdLegado(filmeRequisicao.getIdLegado());
 
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              filmeatualizado.getIdPublico(),
-              filmeatualizado.getNomeFilme(),
-              filmeatualizado.getSinopseFilme(),
-              filmeatualizado.getCategoriaFilme(),
-              filmeatualizado.getAnoFilme(),
-              filmeatualizado.getDiretorFilme());
+        if (filmeRequisicao.getNomeFilme() != null
+                && filmeRequisicao.getIdLegado() != null
+                && filmeExistente.isPresent()) {
+            Filme filmeAtualizado = filmeExistente.get();
+            filmeAtualizado.setNomeFilme(filmeRequisicao.getNomeFilme());
+            filmeRepository.save(filmeAtualizado);
 
-    } else if (filmeExistente.isPresent() && filmeRequisicao.getNomeFilme() == null) {
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem("O nome do filme é obrigatório.");
-    } else {
-      retornoAtualizacaoFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              "Não há filme cadastrado com o ID: "
-                  + filmeRequisicao.getIdPublico()
-                  + ". Faça um POST para inserir.");
+            List<FilmeDTOV1> listaDeFilmes = getListaDeFilmesVersaoUm();
+
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(listaDeFilmes, null);
+        } else if (filmeRequisicao.getNomeFilme() == null || filmeRequisicao.getIdLegado() == null) {
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
+                            null, "O identificador e o nome do filme são obrigatórios.");
+        } else {
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
+                            null, "O registro não existe, faça um POST para inserir.");
+        }
+
+        return retornoAtualizacaoFilme;
     }
 
-    return retornoAtualizacaoFilme;
-  }
+    @Transactional
+    public FilmeResultadoRetornaFilmeOuMensagem atualizarFilmeV2(FilmeDTOV2 filmeRequisicao) {
+        FilmeResultadoRetornaFilmeOuMensagem retornoAtualizacaoFilme = null;
+        Optional<Filme> filmeExistente =
+                filmeRepository.findByIdPublico(filmeRequisicao.getIdPublico());
 
-  @Deprecated
-  @Transactional
-  public FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 deletarFilmePeloIdV1(Integer idRequisicao) {
+        if (filmeRequisicao.getIdPublico() == null) {
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem("É obrigatório informar o ID do filme.");
+        } else if (filmeExistente.isPresent() && filmeRequisicao.getNomeFilme() != null) {
+            Filme filmeatualizado = filmeExistente.get();
+            filmeatualizado.setNomeFilme(filmeRequisicao.getNomeFilme());
+            filmeatualizado.setSinopseFilme(filmeRequisicao.getSinopseFilme());
+            filmeatualizado.setCategoriaFilme(filmeRequisicao.getCategoriaFilme());
+            filmeatualizado.setAnoFilme(filmeRequisicao.getAnoFilme());
+            filmeatualizado.setDiretorFilme(filmeRequisicao.getDiretorFilme());
+            filmeRepository.save(filmeatualizado);
 
-    FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 retornoDeletarFilme = null;
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            filmeatualizado.getIdPublico(),
+                            filmeatualizado.getNomeFilme(),
+                            filmeatualizado.getSinopseFilme(),
+                            filmeatualizado.getCategoriaFilme(),
+                            filmeatualizado.getAnoFilme(),
+                            filmeatualizado.getDiretorFilme());
 
-    Optional<Filme> optionalFilme = filmeRepository.findByIdLegado(idRequisicao);
+        } else if (filmeExistente.isPresent() && filmeRequisicao.getNomeFilme() == null) {
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem("O nome do filme é obrigatório.");
+        } else {
+            retornoAtualizacaoFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            "Não há filme cadastrado com o ID: "
+                                    + filmeRequisicao.getIdPublico()
+                                    + ". Faça um POST para inserir.");
+        }
 
-    if (optionalFilme.isPresent()) {
-      filmeRepository.deleteByIdLegado(idRequisicao);
-
-      List<FilmeDTOV1> listaDeFilmes = getListaDeFilmesVersaoUm();
-
-      retornoDeletarFilme = new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(listaDeFilmes, null);
-    } else {
-      retornoDeletarFilme =
-          new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
-              null, "Identificador não encontrado! Não foi possível excluir o filme.");
+        return retornoAtualizacaoFilme;
     }
 
-    return retornoDeletarFilme;
-  }
+    @Deprecated
+    @Transactional
+    public FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 deletarFilmePeloIdV1(Integer idRequisicao) {
 
-  @Transactional
-  public FilmeResultadoRetornaFilmeOuMensagem deletarFilmePeloIdV2(UUID idRequisicao) {
-    FilmeResultadoRetornaFilmeOuMensagem retornoDeletarFilme = null;
-    Optional<Filme> optionalFilme = filmeRepository.findByIdPublico(idRequisicao);
+        FilmeResultadoRetornaListaDeFilmesOuExcecaoV1 retornoDeletarFilme = null;
 
-    if (optionalFilme.isPresent()) {
-      filmeRepository.deleteByIdPublico(idRequisicao);
-      retornoDeletarFilme = new FilmeResultadoRetornaFilmeOuMensagem("Filme excluído com sucesso!");
-    } else {
-      retornoDeletarFilme =
-          new FilmeResultadoRetornaFilmeOuMensagem(
-              "Identificador não encontrado! Não foi possível excluir o filme.");
+        Optional<Filme> optionalFilme = filmeRepository.findByIdLegado(idRequisicao);
+
+        if (optionalFilme.isPresent()) {
+            filmeRepository.deleteByIdLegado(idRequisicao);
+
+            List<FilmeDTOV1> listaDeFilmes = getListaDeFilmesVersaoUm();
+
+            retornoDeletarFilme = new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(listaDeFilmes, null);
+        } else {
+            retornoDeletarFilme =
+                    new FilmeResultadoRetornaListaDeFilmesOuExcecaoV1(
+                            null, "Identificador não encontrado! Não foi possível excluir o filme.");
+        }
+
+        return retornoDeletarFilme;
     }
 
-    return retornoDeletarFilme;
-  }
+    @Transactional
+    public FilmeResultadoRetornaFilmeOuMensagem deletarFilmePeloIdV2(UUID idRequisicao) {
+        FilmeResultadoRetornaFilmeOuMensagem retornoDeletarFilme = null;
+        Optional<Filme> optionalFilme = filmeRepository.findByIdPublico(idRequisicao);
+
+        if (optionalFilme.isPresent()) {
+            filmeRepository.deleteByIdPublico(idRequisicao);
+            retornoDeletarFilme = new FilmeResultadoRetornaFilmeOuMensagem("Filme excluído com sucesso!");
+        } else {
+            retornoDeletarFilme =
+                    new FilmeResultadoRetornaFilmeOuMensagem(
+                            "Identificador não encontrado! Não foi possível excluir o filme.");
+        }
+
+        return retornoDeletarFilme;
+    }
 }

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
@@ -22,7 +22,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FilmeServiceV1Tests {
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
   private OmdbService omdbService = Mockito.mock(OmdbService.class);
+
+  //Alteração feita aqui
   private FilmeOutboxRepository filmeOutboxRepository = Mockito.mock(FilmeOutboxRepository.class);
+
+  //Alteração feita aqui
   private FilmeService service = new FilmeService(filmeRepository, omdbService, filmeOutboxRepository);
 
   @Test

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
@@ -9,6 +9,7 @@ import com.pagsestagio.movieapi.apiExterna.omdb.service.OmdbService;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeDTOV1;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuExcecaoV1;
+import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import com.pagsestagio.movieapi.repository.FilmeRepository;
 import java.util.Collections;
 import java.util.Optional;
@@ -21,7 +22,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class FilmeServiceV1Tests {
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
   private OmdbService omdbService = Mockito.mock(OmdbService.class);
-  private FilmeService service = new FilmeService(filmeRepository, omdbService);
+  private FilmeOutboxRepository filmeOutboxRepository = Mockito.mock(FilmeOutboxRepository.class);
+  private FilmeService service = new FilmeService(filmeRepository, omdbService, filmeOutboxRepository);
 
   @Test
   public void devePegarUmFilmePorIdQuandoOFilmeExiste() {

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
@@ -1,33 +1,27 @@
 package com.pagsestagio.movieapi.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.pagsestagio.movieapi.apiExterna.omdb.service.OmdbService;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeDTOV1;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuExcecaoV1;
-import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import com.pagsestagio.movieapi.repository.FilmeRepository;
-import java.util.Collections;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @ExtendWith(MockitoExtension.class)
 class FilmeServiceV1Tests {
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
-  private OmdbService omdbService = Mockito.mock(OmdbService.class);
-
-  //Alteração feita aqui
-  private FilmeOutboxRepository filmeOutboxRepository = Mockito.mock(FilmeOutboxRepository.class);
-
-  //Alteração feita aqui
-  private FilmeService service = new FilmeService(filmeRepository, omdbService, filmeOutboxRepository);
+  private FilmeOutboxService filmeOutboxService = Mockito.mock(FilmeOutboxService.class);
+  private FilmeService service = new FilmeService(filmeRepository, filmeOutboxService);
 
   @Test
   public void devePegarUmFilmePorIdQuandoOFilmeExiste() {

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
@@ -22,7 +22,11 @@ class FilmeServiceV2Tests {
 
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
   private OmdbService omdbService = Mockito.mock(OmdbService.class);
+
+  //Alteração feita aqui
   private FilmeOutboxRepository filmeOutboxRepository = Mockito.mock(FilmeOutboxRepository.class);
+
+  //Alteração feita aqui
   private FilmeService service = new FilmeService(filmeRepository, omdbService, filmeOutboxRepository);
 
   @Test

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
@@ -284,4 +284,22 @@ class FilmeServiceV2Tests {
         resultadoFilmeAtualizado.mensagemStatus(),
         "Não deve haver erro ao atualizar um filme existente.");
   }
+
+  @Test
+  public void deveChamarOutboxQuandoFilmeEhCriado() {
+    FilmeDTOV2 novoFilme = new FilmeDTOV2(null, null, null, "Matrix");
+
+    Mockito.when(filmeRepository.findByNomeFilme("Matrix")).thenReturn(Optional.empty());
+    FilmeResultadoRetornaFilmeOuMensagem resultadoFilmeCriado = service.criarFilmeV2(novoFilme);
+    Mockito.verify(filmeRepository).save(Mockito.any(Filme.class));
+    Mockito.verify(filmeOutboxService).salvaEventoNaTabelaDeOutbox(Mockito.any(Filme.class));
+
+    assertNotNull(
+            resultadoFilmeCriado.idpublico(), "O id do filme deve ser retornado após a criação.");
+    assertEquals(
+            "Matrix", resultadoFilmeCriado.nomeFilme(), "O nome do filme retornado deve ser 'Matrix'.");
+    assertNull(
+            resultadoFilmeCriado.mensagemStatus(),
+            "Não deve haver erro ao criar um novo filme com identificador válido.");
+  }
 }

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
@@ -8,6 +8,7 @@ import com.pagsestagio.movieapi.apiExterna.omdb.service.OmdbService;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeDTOV2;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuMensagem;
+import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import com.pagsestagio.movieapi.repository.FilmeRepository;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,7 +22,8 @@ class FilmeServiceV2Tests {
 
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
   private OmdbService omdbService = Mockito.mock(OmdbService.class);
-  private FilmeService service = new FilmeService(filmeRepository, omdbService);
+  private FilmeOutboxRepository filmeOutboxRepository = Mockito.mock(FilmeOutboxRepository.class);
+  private FilmeService service = new FilmeService(filmeRepository, omdbService, filmeOutboxRepository);
 
   @Test
   public void devePegarUmFilmePorIdQuandoOFilmeExiste() {

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
@@ -1,33 +1,27 @@
 package com.pagsestagio.movieapi.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
-import com.pagsestagio.movieapi.apiExterna.omdb.service.OmdbService;
 import com.pagsestagio.movieapi.model.Filme;
 import com.pagsestagio.movieapi.model.FilmeDTOV2;
 import com.pagsestagio.movieapi.model.resultado.FilmeResultadoRetornaFilmeOuMensagem;
-import com.pagsestagio.movieapi.repository.FilmeOutboxRepository;
 import com.pagsestagio.movieapi.repository.FilmeRepository;
-import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 @ExtendWith(MockitoExtension.class)
 class FilmeServiceV2Tests {
 
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
-  private OmdbService omdbService = Mockito.mock(OmdbService.class);
-
-  //Alteração feita aqui
-  private FilmeOutboxRepository filmeOutboxRepository = Mockito.mock(FilmeOutboxRepository.class);
-
-  //Alteração feita aqui
-  private FilmeService service = new FilmeService(filmeRepository, omdbService, filmeOutboxRepository);
+  private FilmeOutboxService filmeOutboxService = Mockito.mock(FilmeOutboxService.class);
+  private FilmeService service = new FilmeService(filmeRepository, filmeOutboxService);
 
   @Test
   public void devePegarUmFilmePorIdQuandoOFilmeExiste() {


### PR DESCRIPTION
📝 Changelog
O que essa mudança altera?
Resposta: A aplicação deixa de fazer diretamente uma chamada à API externa e passa a criar um evento para isso na tabela de outbox.

🎈 Motivação
Por que faremos essa alteração?
Resposta: Adquirir conhecimento prático sobre o "Outbox Pattern".

👷 Solução
Como essa mudança altera? Há Protótipo ou Wireframe de UX/UI que pode ser inserido aqui?
Resposta: É removido o fluxo da aplicação em que se fazia diretamente uma chamada a API externa "Omdb" e passa a ser criado apenas o filme com o seu respectivo nome, sendo salvo um evento na tabela de outbox para que a chamada à API externa ocorra em um outro momento.

📊 Métricas
Como posso medir o sucesso ou o insucesso dessa alteração?
Resposta: Subindo o projeto localmente com docker-compose e verificando se todos os contêineres subiram, Criando um novo filme e vendo se o evento é salvo na tabela de outbox de fato.

📷 Evidências
Como comprovo que essa alteração funciona?
Resposta: