### PR TITLE
BUS-11934 feat: Gerar evento de filme buscado e publicar no tópico

### DIFF
--- a/src/main/java/com/pagsestagio/movieapi/model/EventoFilmePesquisado.java
+++ b/src/main/java/com/pagsestagio/movieapi/model/EventoFilmePesquisado.java
@@ -1,0 +1,11 @@
+package com.pagsestagio.movieapi.model;
+
+import java.time.LocalDateTime;
+
+public record EventoFilmePesquisado(
+        String nomeFilme, String idPublico, String timestamp
+) {
+    public EventoFilmePesquisado(String nomeFilme, String idPublico) {
+        this(nomeFilme, idPublico, LocalDateTime.now().toString());
+    }
+}

--- a/src/test/java/com/pagsestagio/movieapi/IntegrationBaseTest.java
+++ b/src/test/java/com/pagsestagio/movieapi/IntegrationBaseTest.java
@@ -2,6 +2,7 @@ package com.pagsestagio.movieapi;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,4 +10,5 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("dev")
 @AutoConfigureMockMvc
 @Transactional
+@EmbeddedKafka(partitions = 1, topics = { "movie-api.filme-pesquisado" })
 public abstract class IntegrationBaseTest {}

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV1Tests.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -21,7 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FilmeServiceV1Tests {
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
   private FilmeOutboxService filmeOutboxService = Mockito.mock(FilmeOutboxService.class);
-  private FilmeService service = new FilmeService(filmeRepository, filmeOutboxService);
+  private KafkaTemplate<String, String> kafkaTemplate;
+  private FilmeService service = new FilmeService(filmeRepository, filmeOutboxService, kafkaTemplate);
 
   @Test
   public void devePegarUmFilmePorIdQuandoOFilmeExiste() {

--- a/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
+++ b/src/test/java/com/pagsestagio/movieapi/service/FilmeServiceV2Tests.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -17,11 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
+@EmbeddedKafka(partitions = 1, topics = { "movie-api.filme-pesquisado" })
 class FilmeServiceV2Tests {
 
   private FilmeRepository filmeRepository = Mockito.mock(FilmeRepository.class);
   private FilmeOutboxService filmeOutboxService = Mockito.mock(FilmeOutboxService.class);
-  private FilmeService service = new FilmeService(filmeRepository, filmeOutboxService);
+  private KafkaTemplate<String, String> kafkaTemplate = Mockito.mock(KafkaTemplate.class);
+  private FilmeService service = new FilmeService(filmeRepository, filmeOutboxService, kafkaTemplate);
 
   @Test
   public void devePegarUmFilmePorIdQuandoOFilmeExiste() {


### PR DESCRIPTION
📝 Changelog
O que essa mudança altera?
Resposta: Esta alteração envolve a criação de um produtor que será responsável por gerar eventos sempre que um filme for buscado pelo cliente, publicando esses eventos em um tópico Kafka específico.

🎈 Motivação
Por que faremos essa alteração?
Resposta: Proporcionar rastreabilidade das buscas realizadas pelos clientes, permitindo que o sistema registre as ações do usuário para possíveis análises ou reações em tempo real.

👷 Solução
Como essa mudança altera? Há Protótipo ou Wireframe de UX/UI que pode ser inserido aqui?
Resposta: O produtor deve ser configurado para capturar as buscas realizadas pelos clientes e criar eventos contendo as informações do filme pesquisado. Esses eventos serão publicados em um tópico Kafka predefinido.

📊 Métricas
Como posso medir o sucesso ou o insucesso dessa alteração?
Resposta: O produtor deve capturar as buscas e publicar os eventos corretamente no tópico Kafka contendo todas as informações relevantes sobre o filme.

📷 Evidências
Como comprovo que essa alteração funciona?
Resposta:
![image](https://github.com/user-attachments/assets/082cb79b-9934-4ca7-88bb-3971d5f91999)
![image](https://github.com/user-attachments/assets/ca140c40-827d-424e-a75d-db7fada7e411)
![Captura de tela de 2024-12-18 11-12-01](https://github.com/user-attachments/assets/875d36bc-3f08-4a2a-a6ba-96cb30e6c054)
![Captura de tela de 2024-12-18 11-17-17](https://github.com/user-attachments/assets/48e37883-2142-4954-87ee-6ce7f0790afc)
![Captura de tela de 2024-12-18 11-17-25](https://github.com/user-attachments/assets/d7db387e-337e-4d5b-bc1b-a79b18a589f1)
![Captura de tela de 2024-12-18 11-17-29](https://github.com/user-attachments/assets/e5629ed9-4104-48d7-a3ff-0e8cabc8351a)
